### PR TITLE
fix(api/config): remove custom handler, enable CORS, and enforce Python 3.11 runtime

### DIFF
--- a/api/api_requirements.txt
+++ b/api/api_requirements.txt
@@ -1,0 +1,4 @@
+Flask>=3.1.1
+python-dateutil>=2.9.0.post0
+gunicorn>=21.2
+requests>=2.32.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-Flask==2.3.3
+Flask>=3.1.1
 Flask-CORS==4.0.0
 Flask-SQLAlchemy==3.0.5
-python-dateutil==2.8.2
-requests==2.31.0
+python-dateutil>=2.9.0.post0
+requests>=2.32.0
 openai==1.3.0
-Werkzeug==2.3.7
+Werkzeug>=3.0.0
 SQLAlchemy==2.0.21
 Jinja2==3.1.2
 MarkupSafe==2.1.3
@@ -31,3 +31,4 @@ attrs==23.1.0
 frozenlist==1.4.0
 multidict==6.0.4
 yarl==1.9.2
+gunicorn>=21.2

--- a/vercel.json
+++ b/vercel.json
@@ -1,28 +1,21 @@
 {
+  "functions": {
+    "api/*.py": { "runtime": "python3.11" }
+  },
   "rewrites": [
+    { "source": "/checkup-intelligent", "destination": "/api/checkup-intelligent" },
+    { "source": "/checkup", "destination": "/api/checkup" },
+    { "source": "/api/analytics/(.*)", "destination": "/api/analytics.py" },
+    { "source": "/analytics", "destination": "/analytics.html" },
+    { "source": "/analytics.html", "destination": "/analytics.html" },
+    { "source": "/(.*)", "destination": "/index.html" }
+  ],
+  "headers": [
     {
-      "source": "/api/checkup",
-      "destination": "/api/checkup.py"
-    },
-    {
-      "source": "/api/analytics/(.*)",
-      "destination": "/api/analytics.py"
-    },
-    {
-      "source": "/checkup-intelligent",
-      "destination": "/api/checkup-intelligent.py"
-    },
-    {
-      "source": "/analytics",
-      "destination": "/analytics.html"
-    },
-    {
-      "source": "/analytics.html",
-      "destination": "/analytics.html"
-    },
-    {
-      "source": "/(.*)",
-      "destination": "/index.html"
+      "source": "/(checkup|checkup-intelligent)",
+      "headers": [
+        { "key": "Access-Control-Allow-Origin", "value": "*" }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This pull request applies the following fixes to resolve the HTTP 500 errors when generating recommendations:

- **Remove custom `handler` functions** from `api/checkup-intelligent.py` and `api/checkup.py`, letting Vercel detect the Flask `app` automatically.
- **Add `_corsify` helper** and support for `POST`/`OPTIONS` with CORS headers to both API endpoints.
- Use `request.get_json(silent=True)` to avoid crashing on malformed JSON.
- **Update `vercel.json`** to set Python 3.11 runtime for the functions, define rewrites for `/checkup-intelligent` and `/checkup`, and add CORS headers.
- **Update dependencies** in root `requirements.txt` and API `requirements.txt` to include Flask 3.1, python-dateutil, gunicorn, requests, etc.

These changes should eliminate the TypeError from the runtime and allow the `/checkup-intelligent` endpoint to return recommendations without HTTP 500 errors. After merging, a new deployment should run with Python 3.11 and handle requests correctly.
