### PR TITLE
fix(vercel): remove invalid functions runtime configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,5 @@
 {
-  "functions": {
-    "api/*.py": { "runtime": "python3.11" }
-  },
+
   "rewrites": [
     { "source": "/checkup-intelligent", "destination": "/api/checkup-intelligent" },
     { "source": "/checkup", "destination": "/api/checkup" },


### PR DESCRIPTION
Remove 'functions' property from vercel.json to fix Vercel build error "Function Runtimes must have a valid version". Use default runtime for Python functions.