### PR TITLE
Accept laboratorio category alias

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -542,7 +542,8 @@
                           item.titulo.toLowerCase().includes('eletrocardiograma') ||
                           item.titulo.toLowerCase().includes('fundoscopia')) {
                     category = 'Exames de Imagem';
-                } else if (item.categoria === 'laboratorial' ||
+                // Aceita tanto 'laboratorial' quanto 'laboratorio' para compatibilidade
+                } else if ((item.categoria === 'laboratorial' || item.categoria === 'laboratorio') ||
                           item.titulo.toLowerCase().includes('hba1c') ||
                           item.titulo.toLowerCase().includes('creatinina') ||
                           item.titulo.toLowerCase().includes('perfil') ||

--- a/index.html
+++ b/index.html
@@ -545,7 +545,8 @@
                           item.titulo.toLowerCase().includes('eletrocardiograma') ||
                           item.titulo.toLowerCase().includes('fundoscopia')) {
                     category = 'Exames de Imagem';
-                } else if (item.categoria === 'laboratorial' ||
+                // Aceita tanto 'laboratorial' quanto 'laboratorio' para compatibilidade
+                } else if ((item.categoria === 'laboratorial' || item.categoria === 'laboratorio') ||
                           item.titulo.toLowerCase().includes('hba1c') ||
                           item.titulo.toLowerCase().includes('creatinina') ||
                           item.titulo.toLowerCase().includes('perfil') ||

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -765,7 +765,13 @@
             };
 
             Object.keys(categories).forEach(category => {
-                const categoryRecs = recommendations.filter(rec => rec.categoria === category);
+                const categoryRecs = recommendations.filter(rec => {
+                    // Aceita tanto 'laboratorial' quanto 'laboratorio' para compatibilidade de dados
+                    if (category === 'laboratorio') {
+                        return rec.categoria === 'laboratorio' || rec.categoria === 'laboratorial';
+                    }
+                    return rec.categoria === category;
+                });
                 if (categoryRecs.length > 0) {
                     const categoryDiv = document.createElement('div');
                     categoryDiv.innerHTML = `<h3 style="color: #2d3748; margin: 20px 0 15px 0;">${categories[category]}</h3>`;

--- a/src/static/index.html.new
+++ b/src/static/index.html.new
@@ -1197,7 +1197,8 @@
                           item.titulo.toLowerCase().includes('eletrocardiograma') ||
                           item.titulo.toLowerCase().includes('fundoscopia')) {
                     category = 'Exames de Imagem';
-                } else if (item.categoria === 'laboratorial' ||
+                // Aceita tanto 'laboratorial' quanto 'laboratorio' para compatibilidade
+                } else if ((item.categoria === 'laboratorial' || item.categoria === 'laboratorio') ||
                           item.titulo.toLowerCase().includes('hba1c') ||
                           item.titulo.toLowerCase().includes('creatinina') ||
                           item.titulo.toLowerCase().includes('perfil') ||

--- a/src/static/index.html.original
+++ b/src/static/index.html.original
@@ -542,7 +542,8 @@
                           item.titulo.toLowerCase().includes('eletrocardiograma') ||
                           item.titulo.toLowerCase().includes('fundoscopia')) {
                     category = 'Exames de Imagem';
-                } else if (item.categoria === 'laboratorial' ||
+                // Aceita tanto 'laboratorial' quanto 'laboratorio' para compatibilidade
+                } else if ((item.categoria === 'laboratorial' || item.categoria === 'laboratorio') ||
                           item.titulo.toLowerCase().includes('hba1c') ||
                           item.titulo.toLowerCase().includes('creatinina') ||
                           item.titulo.toLowerCase().includes('perfil') ||


### PR DESCRIPTION
## Summary
- allow both `laboratorio` and `laboratorial` when classifying laboratory recommendations across the static HTML bundles
- document the new accepted alias directly in the categorization logic and update the dashboard filter to handle both values

## Testing
- not run (static content update)


------
https://chatgpt.com/codex/tasks/task_e_68c856ae6b2883309f618c636356204a