### PR TITLE
Handle "laboratorio" category alias directly

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -512,9 +512,14 @@
             // Verificar se há alertas
             const alerts = recommendations.alerts || [];
             const recs = recommendations.recommendations || recommendations;
-            
+            // Normaliza categorias para aceitar "laboratorio" (sem "al") como sinônimo de "laboratorial"
+            const normalizedRecs = recs.map(item => ({
+                ...item,
+                categoria: item.categoria === 'laboratorio' ? 'laboratorial' : item.categoria
+            }));
+
             // Salvar recomendações para uso posterior
-            lastRecommendations = recs;
+            lastRecommendations = normalizedRecs;
             
             // Organizar recomendações por categoria
             const categories = {
@@ -525,7 +530,7 @@
                 'Outras Recomendações': []
             };
             
-            recs.forEach(item => {
+            normalizedRecs.forEach(item => {
                 let category = 'Outras Recomendações';
 
                 if (item.categoria && item.categoria.includes('vacina')) {
@@ -542,8 +547,7 @@
                           item.titulo.toLowerCase().includes('eletrocardiograma') ||
                           item.titulo.toLowerCase().includes('fundoscopia')) {
                     category = 'Exames de Imagem';
-                // Aceita explicitamente o valor "laboratorio" (sem "al") além de "laboratorial"
-                } else if ((item.categoria === 'laboratorial' || item.categoria === 'laboratorio') ||
+                } else if (item.categoria === 'laboratorial' ||
                           item.titulo.toLowerCase().includes('hba1c') ||
                           item.titulo.toLowerCase().includes('creatinina') ||
                           item.titulo.toLowerCase().includes('perfil') ||

--- a/dist/index.html
+++ b/dist/index.html
@@ -527,10 +527,10 @@
             
             recs.forEach(item => {
                 let category = 'Outras Recomendações';
-                
+
                 if (item.categoria && item.categoria.includes('vacina')) {
                     category = 'Vacinas';
-                } else if (item.titulo.toLowerCase().includes('mamografia') || 
+                } else if (item.titulo.toLowerCase().includes('mamografia') ||
                           item.titulo.toLowerCase().includes('colonoscopia') ||
                           item.titulo.toLowerCase().includes('citologia') ||
                           item.titulo.toLowerCase().includes('psa') ||
@@ -542,7 +542,8 @@
                           item.titulo.toLowerCase().includes('eletrocardiograma') ||
                           item.titulo.toLowerCase().includes('fundoscopia')) {
                     category = 'Exames de Imagem';
-                } else if (item.categoria === 'laboratorial' ||
+                // Aceita explicitamente o valor "laboratorio" (sem "al") além de "laboratorial"
+                } else if ((item.categoria === 'laboratorial' || item.categoria === 'laboratorio') ||
                           item.titulo.toLowerCase().includes('hba1c') ||
                           item.titulo.toLowerCase().includes('creatinina') ||
                           item.titulo.toLowerCase().includes('perfil') ||

--- a/index.html
+++ b/index.html
@@ -530,10 +530,10 @@
             
             recs.forEach(item => {
                 let category = 'Outras Recomendações';
-                
+
                 if (item.categoria && item.categoria.includes('vacina')) {
                     category = 'Vacinas';
-                } else if (item.titulo.toLowerCase().includes('mamografia') || 
+                } else if (item.titulo.toLowerCase().includes('mamografia') ||
                           item.titulo.toLowerCase().includes('colonoscopia') ||
                           item.titulo.toLowerCase().includes('citologia') ||
                           item.titulo.toLowerCase().includes('psa') ||
@@ -545,7 +545,8 @@
                           item.titulo.toLowerCase().includes('eletrocardiograma') ||
                           item.titulo.toLowerCase().includes('fundoscopia')) {
                     category = 'Exames de Imagem';
-                } else if (item.categoria === 'laboratorial' ||
+                // Aceita explicitamente o valor "laboratorio" (sem "al") além de "laboratorial"
+                } else if ((item.categoria === 'laboratorial' || item.categoria === 'laboratorio') ||
                           item.titulo.toLowerCase().includes('hba1c') ||
                           item.titulo.toLowerCase().includes('creatinina') ||
                           item.titulo.toLowerCase().includes('perfil') ||

--- a/index.html
+++ b/index.html
@@ -515,9 +515,14 @@
             // Verificar se há alertas
             const alerts = recommendations.alerts || [];
             const recs = recommendations.recommendations || recommendations;
-            
+            // Normaliza categorias para aceitar "laboratorio" (sem "al") como sinônimo de "laboratorial"
+            const normalizedRecs = recs.map(item => ({
+                ...item,
+                categoria: item.categoria === 'laboratorio' ? 'laboratorial' : item.categoria
+            }));
+
             // Salvar recomendações para uso posterior
-            lastRecommendations = recs;
+            lastRecommendations = normalizedRecs;
             
             // Organizar recomendações por categoria
             const categories = {
@@ -528,7 +533,7 @@
                 'Outras Recomendações': []
             };
             
-            recs.forEach(item => {
+            normalizedRecs.forEach(item => {
                 let category = 'Outras Recomendações';
 
                 if (item.categoria && item.categoria.includes('vacina')) {
@@ -545,8 +550,7 @@
                           item.titulo.toLowerCase().includes('eletrocardiograma') ||
                           item.titulo.toLowerCase().includes('fundoscopia')) {
                     category = 'Exames de Imagem';
-                // Aceita explicitamente o valor "laboratorio" (sem "al") além de "laboratorial"
-                } else if ((item.categoria === 'laboratorial' || item.categoria === 'laboratorio') ||
+                } else if (item.categoria === 'laboratorial' ||
                           item.titulo.toLowerCase().includes('hba1c') ||
                           item.titulo.toLowerCase().includes('creatinina') ||
                           item.titulo.toLowerCase().includes('perfil') ||

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -757,6 +757,12 @@
             const container = document.getElementById('recommendations');
             container.innerHTML = '';
 
+            // Normaliza categorias para aceitar "laboratorio" (sem "al") como sinônimo de "laboratorial"
+            const normalizedRecommendations = recommendations.map(rec => ({
+                ...rec,
+                categoria: rec.categoria === 'laboratorial' ? 'laboratorio' : rec.categoria
+            }));
+
             const categories = {
                 'laboratorio': '🧪 Exames Laboratoriais',
                 'imagem': '📷 Exames de Imagem',
@@ -765,13 +771,7 @@
             };
 
             Object.keys(categories).forEach(category => {
-                const categoryRecs = recommendations.filter(rec => {
-                    if (category === 'laboratorio') {
-                        // Aceita explicitamente tanto 'laboratorial' quanto 'laboratorio'
-                        return rec.categoria === 'laboratorial' || rec.categoria === 'laboratorio';
-                    }
-                    return rec.categoria === category;
-                });
+                const categoryRecs = normalizedRecommendations.filter(rec => rec.categoria === category);
                 if (categoryRecs.length > 0) {
                     const categoryDiv = document.createElement('div');
                     categoryDiv.innerHTML = `<h3 style="color: #2d3748; margin: 20px 0 15px 0;">${categories[category]}</h3>`;

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -765,7 +765,13 @@
             };
 
             Object.keys(categories).forEach(category => {
-                const categoryRecs = recommendations.filter(rec => rec.categoria === category);
+                const categoryRecs = recommendations.filter(rec => {
+                    if (category === 'laboratorio') {
+                        // Aceita explicitamente tanto 'laboratorial' quanto 'laboratorio'
+                        return rec.categoria === 'laboratorial' || rec.categoria === 'laboratorio';
+                    }
+                    return rec.categoria === category;
+                });
                 if (categoryRecs.length > 0) {
                     const categoryDiv = document.createElement('div');
                     categoryDiv.innerHTML = `<h3 style="color: #2d3748; margin: 20px 0 15px 0;">${categories[category]}</h3>`;

--- a/src/static/index.html.new
+++ b/src/static/index.html.new
@@ -1167,9 +1167,14 @@
             // Verificar se há alertas
             const alerts = recommendations.alerts || [];
             const recs = recommendations.recommendations || recommendations;
-            
+            // Normaliza categorias para aceitar "laboratorio" (sem "al") como sinônimo de "laboratorial"
+            const normalizedRecs = recs.map(item => ({
+                ...item,
+                categoria: item.categoria === 'laboratorio' ? 'laboratorial' : item.categoria
+            }));
+
             // Salvar recomendações para uso posterior
-            lastRecommendations = recs;
+            lastRecommendations = normalizedRecs;
             
             // Organizar recomendações por categoria
             const categories = {
@@ -1180,7 +1185,7 @@
                 'Outras Recomendações': []
             };
             
-            recs.forEach(item => {
+            normalizedRecs.forEach(item => {
                 let category = 'Outras Recomendações';
 
                 if (item.categoria && item.categoria.includes('vacina')) {
@@ -1197,8 +1202,7 @@
                           item.titulo.toLowerCase().includes('eletrocardiograma') ||
                           item.titulo.toLowerCase().includes('fundoscopia')) {
                     category = 'Exames de Imagem';
-                // Aceita explicitamente o valor "laboratorio" (sem "al") além de "laboratorial"
-                } else if ((item.categoria === 'laboratorial' || item.categoria === 'laboratorio') ||
+                } else if (item.categoria === 'laboratorial' ||
                           item.titulo.toLowerCase().includes('hba1c') ||
                           item.titulo.toLowerCase().includes('creatinina') ||
                           item.titulo.toLowerCase().includes('perfil') ||

--- a/src/static/index.html.new
+++ b/src/static/index.html.new
@@ -1182,10 +1182,10 @@
             
             recs.forEach(item => {
                 let category = 'Outras Recomendações';
-                
+
                 if (item.categoria && item.categoria.includes('vacina')) {
                     category = 'Vacinas';
-                } else if (item.titulo.toLowerCase().includes('mamografia') || 
+                } else if (item.titulo.toLowerCase().includes('mamografia') ||
                           item.titulo.toLowerCase().includes('colonoscopia') ||
                           item.titulo.toLowerCase().includes('citologia') ||
                           item.titulo.toLowerCase().includes('psa') ||
@@ -1197,7 +1197,8 @@
                           item.titulo.toLowerCase().includes('eletrocardiograma') ||
                           item.titulo.toLowerCase().includes('fundoscopia')) {
                     category = 'Exames de Imagem';
-                } else if (item.categoria === 'laboratorial' ||
+                // Aceita explicitamente o valor "laboratorio" (sem "al") além de "laboratorial"
+                } else if ((item.categoria === 'laboratorial' || item.categoria === 'laboratorio') ||
                           item.titulo.toLowerCase().includes('hba1c') ||
                           item.titulo.toLowerCase().includes('creatinina') ||
                           item.titulo.toLowerCase().includes('perfil') ||

--- a/src/static/index.html.original
+++ b/src/static/index.html.original
@@ -512,9 +512,14 @@
             // Verificar se há alertas
             const alerts = recommendations.alerts || [];
             const recs = recommendations.recommendations || recommendations;
-            
+            // Normaliza categorias para aceitar "laboratorio" (sem "al") como sinônimo de "laboratorial"
+            const normalizedRecs = recs.map(item => ({
+                ...item,
+                categoria: item.categoria === 'laboratorio' ? 'laboratorial' : item.categoria
+            }));
+
             // Salvar recomendações para uso posterior
-            lastRecommendations = recs;
+            lastRecommendations = normalizedRecs;
             
             // Organizar recomendações por categoria
             const categories = {
@@ -525,7 +530,7 @@
                 'Outras Recomendações': []
             };
             
-            recs.forEach(item => {
+            normalizedRecs.forEach(item => {
                 let category = 'Outras Recomendações';
 
                 if (item.categoria && item.categoria.includes('vacina')) {
@@ -542,8 +547,7 @@
                           item.titulo.toLowerCase().includes('eletrocardiograma') ||
                           item.titulo.toLowerCase().includes('fundoscopia')) {
                     category = 'Exames de Imagem';
-                // Aceita explicitamente o valor "laboratorio" (sem "al") além de "laboratorial"
-                } else if ((item.categoria === 'laboratorial' || item.categoria === 'laboratorio') ||
+                } else if (item.categoria === 'laboratorial' ||
                           item.titulo.toLowerCase().includes('hba1c') ||
                           item.titulo.toLowerCase().includes('creatinina') ||
                           item.titulo.toLowerCase().includes('perfil') ||

--- a/src/static/index.html.original
+++ b/src/static/index.html.original
@@ -527,10 +527,10 @@
             
             recs.forEach(item => {
                 let category = 'Outras Recomendações';
-                
+
                 if (item.categoria && item.categoria.includes('vacina')) {
                     category = 'Vacinas';
-                } else if (item.titulo.toLowerCase().includes('mamografia') || 
+                } else if (item.titulo.toLowerCase().includes('mamografia') ||
                           item.titulo.toLowerCase().includes('colonoscopia') ||
                           item.titulo.toLowerCase().includes('citologia') ||
                           item.titulo.toLowerCase().includes('psa') ||
@@ -542,7 +542,8 @@
                           item.titulo.toLowerCase().includes('eletrocardiograma') ||
                           item.titulo.toLowerCase().includes('fundoscopia')) {
                     category = 'Exames de Imagem';
-                } else if (item.categoria === 'laboratorial' ||
+                // Aceita explicitamente o valor "laboratorio" (sem "al") além de "laboratorial"
+                } else if ((item.categoria === 'laboratorial' || item.categoria === 'laboratorio') ||
                           item.titulo.toLowerCase().includes('hba1c') ||
                           item.titulo.toLowerCase().includes('creatinina') ||
                           item.titulo.toLowerCase().includes('perfil') ||


### PR DESCRIPTION
## Summary
- remove the temporary Set helper from each HTML bundle and keep the existing category checks intact
- treat both `laboratorial` and the new `laboratorio` value as laboratory recommendations in each generated variant
- add inline comments noting that the alias without "al" is supported when grouping recommendations

## Testing
- not run (static HTML update)


------
https://chatgpt.com/codex/tasks/task_e_68c856ae6b2883309f618c636356204a