### PR TITLE
Handle laboratorio alias in recommendation views

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -512,7 +512,9 @@
             // Verificar se há alertas
             const alerts = recommendations.alerts || [];
             const recs = recommendations.recommendations || recommendations;
-            
+            // Considera "laboratorio" (sem "al") e "laboratorial" como categorias laboratoriais equivalentes
+            const isLaboratoryCategory = categoria => categoria === 'laboratorial' || categoria === 'laboratorio';
+
             // Salvar recomendações para uso posterior
             lastRecommendations = recs;
             
@@ -527,10 +529,10 @@
             
             recs.forEach(item => {
                 let category = 'Outras Recomendações';
-                
+
                 if (item.categoria && item.categoria.includes('vacina')) {
                     category = 'Vacinas';
-                } else if (item.titulo.toLowerCase().includes('mamografia') || 
+                } else if (item.titulo.toLowerCase().includes('mamografia') ||
                           item.titulo.toLowerCase().includes('colonoscopia') ||
                           item.titulo.toLowerCase().includes('citologia') ||
                           item.titulo.toLowerCase().includes('psa') ||
@@ -542,7 +544,7 @@
                           item.titulo.toLowerCase().includes('eletrocardiograma') ||
                           item.titulo.toLowerCase().includes('fundoscopia')) {
                     category = 'Exames de Imagem';
-                } else if (item.categoria === 'laboratorial' ||
+                } else if (isLaboratoryCategory(item.categoria) ||
                           item.titulo.toLowerCase().includes('hba1c') ||
                           item.titulo.toLowerCase().includes('creatinina') ||
                           item.titulo.toLowerCase().includes('perfil') ||

--- a/index.html
+++ b/index.html
@@ -515,7 +515,9 @@
             // Verificar se há alertas
             const alerts = recommendations.alerts || [];
             const recs = recommendations.recommendations || recommendations;
-            
+            // Considera "laboratorio" (sem "al") e "laboratorial" como categorias laboratoriais equivalentes
+            const isLaboratoryCategory = categoria => categoria === 'laboratorial' || categoria === 'laboratorio';
+
             // Salvar recomendações para uso posterior
             lastRecommendations = recs;
             
@@ -530,10 +532,10 @@
             
             recs.forEach(item => {
                 let category = 'Outras Recomendações';
-                
+
                 if (item.categoria && item.categoria.includes('vacina')) {
                     category = 'Vacinas';
-                } else if (item.titulo.toLowerCase().includes('mamografia') || 
+                } else if (item.titulo.toLowerCase().includes('mamografia') ||
                           item.titulo.toLowerCase().includes('colonoscopia') ||
                           item.titulo.toLowerCase().includes('citologia') ||
                           item.titulo.toLowerCase().includes('psa') ||
@@ -545,7 +547,7 @@
                           item.titulo.toLowerCase().includes('eletrocardiograma') ||
                           item.titulo.toLowerCase().includes('fundoscopia')) {
                     category = 'Exames de Imagem';
-                } else if (item.categoria === 'laboratorial' ||
+                } else if (isLaboratoryCategory(item.categoria) ||
                           item.titulo.toLowerCase().includes('hba1c') ||
                           item.titulo.toLowerCase().includes('creatinina') ||
                           item.titulo.toLowerCase().includes('perfil') ||

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -757,6 +757,9 @@
             const container = document.getElementById('recommendations');
             container.innerHTML = '';
 
+            // Aceita "laboratorio" (sem "al") e "laboratorial" como categorias laboratoriais equivalentes
+            const isLaboratoryCategory = categoria => categoria === 'laboratorio' || categoria === 'laboratorial';
+
             const categories = {
                 'laboratorio': '🧪 Exames Laboratoriais',
                 'imagem': '📷 Exames de Imagem',
@@ -765,11 +768,17 @@
             };
 
             Object.keys(categories).forEach(category => {
-                const categoryRecs = recommendations.filter(rec => rec.categoria === category);
+                const categoryRecs = recommendations.filter(rec => {
+                    if (category === 'laboratorio') {
+                        return isLaboratoryCategory(rec.categoria);
+                    }
+
+                    return rec.categoria === category;
+                });
                 if (categoryRecs.length > 0) {
                     const categoryDiv = document.createElement('div');
                     categoryDiv.innerHTML = `<h3 style="color: #2d3748; margin: 20px 0 15px 0;">${categories[category]}</h3>`;
-                    
+
                     categoryRecs.forEach(rec => {
                         const recDiv = document.createElement('div');
                         recDiv.className = `recommendation-item ${rec.prioridade}`;

--- a/src/static/index.html.new
+++ b/src/static/index.html.new
@@ -1167,7 +1167,9 @@
             // Verificar se há alertas
             const alerts = recommendations.alerts || [];
             const recs = recommendations.recommendations || recommendations;
-            
+            // Considera "laboratorio" (sem "al") e "laboratorial" como categorias laboratoriais equivalentes
+            const isLaboratoryCategory = categoria => categoria === 'laboratorial' || categoria === 'laboratorio';
+
             // Salvar recomendações para uso posterior
             lastRecommendations = recs;
             
@@ -1182,10 +1184,10 @@
             
             recs.forEach(item => {
                 let category = 'Outras Recomendações';
-                
+
                 if (item.categoria && item.categoria.includes('vacina')) {
                     category = 'Vacinas';
-                } else if (item.titulo.toLowerCase().includes('mamografia') || 
+                } else if (item.titulo.toLowerCase().includes('mamografia') ||
                           item.titulo.toLowerCase().includes('colonoscopia') ||
                           item.titulo.toLowerCase().includes('citologia') ||
                           item.titulo.toLowerCase().includes('psa') ||
@@ -1197,7 +1199,7 @@
                           item.titulo.toLowerCase().includes('eletrocardiograma') ||
                           item.titulo.toLowerCase().includes('fundoscopia')) {
                     category = 'Exames de Imagem';
-                } else if (item.categoria === 'laboratorial' ||
+                } else if (isLaboratoryCategory(item.categoria) ||
                           item.titulo.toLowerCase().includes('hba1c') ||
                           item.titulo.toLowerCase().includes('creatinina') ||
                           item.titulo.toLowerCase().includes('perfil') ||

--- a/src/static/index.html.original
+++ b/src/static/index.html.original
@@ -512,7 +512,9 @@
             // Verificar se há alertas
             const alerts = recommendations.alerts || [];
             const recs = recommendations.recommendations || recommendations;
-            
+            // Considera "laboratorio" (sem "al") e "laboratorial" como categorias laboratoriais equivalentes
+            const isLaboratoryCategory = categoria => categoria === 'laboratorial' || categoria === 'laboratorio';
+
             // Salvar recomendações para uso posterior
             lastRecommendations = recs;
             
@@ -527,10 +529,10 @@
             
             recs.forEach(item => {
                 let category = 'Outras Recomendações';
-                
+
                 if (item.categoria && item.categoria.includes('vacina')) {
                     category = 'Vacinas';
-                } else if (item.titulo.toLowerCase().includes('mamografia') || 
+                } else if (item.titulo.toLowerCase().includes('mamografia') ||
                           item.titulo.toLowerCase().includes('colonoscopia') ||
                           item.titulo.toLowerCase().includes('citologia') ||
                           item.titulo.toLowerCase().includes('psa') ||
@@ -542,7 +544,7 @@
                           item.titulo.toLowerCase().includes('eletrocardiograma') ||
                           item.titulo.toLowerCase().includes('fundoscopia')) {
                     category = 'Exames de Imagem';
-                } else if (item.categoria === 'laboratorial' ||
+                } else if (isLaboratoryCategory(item.categoria) ||
                           item.titulo.toLowerCase().includes('hba1c') ||
                           item.titulo.toLowerCase().includes('creatinina') ||
                           item.titulo.toLowerCase().includes('perfil') ||


### PR DESCRIPTION
## Summary
- treat both `laboratorio` and `laboratorial` values as laboratory categories when grouping results in the interactive index bundles without mutating the original payloads
- adjust the static recommendation view to filter laboratory exams using the same alias-aware helper and document the accepted values in comments

## Testing
- not run (static HTML update)

------
https://chatgpt.com/codex/tasks/task_e_68c856ae6b2883309f618c636356204a