### PR TITLE
Normalize laboratory category alias handling

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -512,7 +512,14 @@
             // Verificar se há alertas
             const alerts = recommendations.alerts || [];
             const recs = recommendations.recommendations || recommendations;
-            
+            // Aceita as variações "laboratorio" (sem "al") e "laboratorial" como categorias laboratoriais equivalentes
+            const LAB_CATEGORY_VALUES = ['laboratorial', 'laboratorio'];
+            const isLaboratoryCategory = categoria => {
+                if (!categoria) return false;
+                const normalizedCategory = String(categoria).trim().toLowerCase();
+                return LAB_CATEGORY_VALUES.includes(normalizedCategory);
+            };
+
             // Salvar recomendações para uso posterior
             lastRecommendations = recs;
             
@@ -527,10 +534,10 @@
             
             recs.forEach(item => {
                 let category = 'Outras Recomendações';
-                
+
                 if (item.categoria && item.categoria.includes('vacina')) {
                     category = 'Vacinas';
-                } else if (item.titulo.toLowerCase().includes('mamografia') || 
+                } else if (item.titulo.toLowerCase().includes('mamografia') ||
                           item.titulo.toLowerCase().includes('colonoscopia') ||
                           item.titulo.toLowerCase().includes('citologia') ||
                           item.titulo.toLowerCase().includes('psa') ||
@@ -542,7 +549,7 @@
                           item.titulo.toLowerCase().includes('eletrocardiograma') ||
                           item.titulo.toLowerCase().includes('fundoscopia')) {
                     category = 'Exames de Imagem';
-                } else if (item.categoria === 'laboratorial' ||
+                } else if (isLaboratoryCategory(item.categoria) ||
                           item.titulo.toLowerCase().includes('hba1c') ||
                           item.titulo.toLowerCase().includes('creatinina') ||
                           item.titulo.toLowerCase().includes('perfil') ||

--- a/index.html
+++ b/index.html
@@ -515,7 +515,14 @@
             // Verificar se há alertas
             const alerts = recommendations.alerts || [];
             const recs = recommendations.recommendations || recommendations;
-            
+            // Aceita as variações "laboratorio" (sem "al") e "laboratorial" como categorias laboratoriais equivalentes
+            const LAB_CATEGORY_VALUES = ['laboratorial', 'laboratorio'];
+            const isLaboratoryCategory = categoria => {
+                if (!categoria) return false;
+                const normalizedCategory = String(categoria).trim().toLowerCase();
+                return LAB_CATEGORY_VALUES.includes(normalizedCategory);
+            };
+
             // Salvar recomendações para uso posterior
             lastRecommendations = recs;
             
@@ -530,10 +537,10 @@
             
             recs.forEach(item => {
                 let category = 'Outras Recomendações';
-                
+
                 if (item.categoria && item.categoria.includes('vacina')) {
                     category = 'Vacinas';
-                } else if (item.titulo.toLowerCase().includes('mamografia') || 
+                } else if (item.titulo.toLowerCase().includes('mamografia') ||
                           item.titulo.toLowerCase().includes('colonoscopia') ||
                           item.titulo.toLowerCase().includes('citologia') ||
                           item.titulo.toLowerCase().includes('psa') ||
@@ -545,7 +552,7 @@
                           item.titulo.toLowerCase().includes('eletrocardiograma') ||
                           item.titulo.toLowerCase().includes('fundoscopia')) {
                     category = 'Exames de Imagem';
-                } else if (item.categoria === 'laboratorial' ||
+                } else if (isLaboratoryCategory(item.categoria) ||
                           item.titulo.toLowerCase().includes('hba1c') ||
                           item.titulo.toLowerCase().includes('creatinina') ||
                           item.titulo.toLowerCase().includes('perfil') ||

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -757,6 +757,14 @@
             const container = document.getElementById('recommendations');
             container.innerHTML = '';
 
+            // Aceita as variações "laboratorio" (sem "al") e "laboratorial" como categorias laboratoriais equivalentes
+            const LAB_CATEGORY_VALUES = ['laboratorial', 'laboratorio'];
+            const isLaboratoryCategory = categoria => {
+                if (!categoria) return false;
+                const normalizedCategory = String(categoria).trim().toLowerCase();
+                return LAB_CATEGORY_VALUES.includes(normalizedCategory);
+            };
+
             const categories = {
                 'laboratorio': '🧪 Exames Laboratoriais',
                 'imagem': '📷 Exames de Imagem',
@@ -765,11 +773,17 @@
             };
 
             Object.keys(categories).forEach(category => {
-                const categoryRecs = recommendations.filter(rec => rec.categoria === category);
+                const categoryRecs = recommendations.filter(rec => {
+                    if (category === 'laboratorio') {
+                        return isLaboratoryCategory(rec.categoria);
+                    }
+
+                    return rec.categoria === category;
+                });
                 if (categoryRecs.length > 0) {
                     const categoryDiv = document.createElement('div');
                     categoryDiv.innerHTML = `<h3 style="color: #2d3748; margin: 20px 0 15px 0;">${categories[category]}</h3>`;
-                    
+
                     categoryRecs.forEach(rec => {
                         const recDiv = document.createElement('div');
                         recDiv.className = `recommendation-item ${rec.prioridade}`;

--- a/src/static/index.html.new
+++ b/src/static/index.html.new
@@ -1167,7 +1167,14 @@
             // Verificar se há alertas
             const alerts = recommendations.alerts || [];
             const recs = recommendations.recommendations || recommendations;
-            
+            // Aceita as variações "laboratorio" (sem "al") e "laboratorial" como categorias laboratoriais equivalentes
+            const LAB_CATEGORY_VALUES = ['laboratorial', 'laboratorio'];
+            const isLaboratoryCategory = categoria => {
+                if (!categoria) return false;
+                const normalizedCategory = String(categoria).trim().toLowerCase();
+                return LAB_CATEGORY_VALUES.includes(normalizedCategory);
+            };
+
             // Salvar recomendações para uso posterior
             lastRecommendations = recs;
             
@@ -1182,10 +1189,10 @@
             
             recs.forEach(item => {
                 let category = 'Outras Recomendações';
-                
+
                 if (item.categoria && item.categoria.includes('vacina')) {
                     category = 'Vacinas';
-                } else if (item.titulo.toLowerCase().includes('mamografia') || 
+                } else if (item.titulo.toLowerCase().includes('mamografia') ||
                           item.titulo.toLowerCase().includes('colonoscopia') ||
                           item.titulo.toLowerCase().includes('citologia') ||
                           item.titulo.toLowerCase().includes('psa') ||
@@ -1197,7 +1204,7 @@
                           item.titulo.toLowerCase().includes('eletrocardiograma') ||
                           item.titulo.toLowerCase().includes('fundoscopia')) {
                     category = 'Exames de Imagem';
-                } else if (item.categoria === 'laboratorial' ||
+                } else if (isLaboratoryCategory(item.categoria) ||
                           item.titulo.toLowerCase().includes('hba1c') ||
                           item.titulo.toLowerCase().includes('creatinina') ||
                           item.titulo.toLowerCase().includes('perfil') ||

--- a/src/static/index.html.original
+++ b/src/static/index.html.original
@@ -512,7 +512,14 @@
             // Verificar se há alertas
             const alerts = recommendations.alerts || [];
             const recs = recommendations.recommendations || recommendations;
-            
+            // Aceita as variações "laboratorio" (sem "al") e "laboratorial" como categorias laboratoriais equivalentes
+            const LAB_CATEGORY_VALUES = ['laboratorial', 'laboratorio'];
+            const isLaboratoryCategory = categoria => {
+                if (!categoria) return false;
+                const normalizedCategory = String(categoria).trim().toLowerCase();
+                return LAB_CATEGORY_VALUES.includes(normalizedCategory);
+            };
+
             // Salvar recomendações para uso posterior
             lastRecommendations = recs;
             
@@ -527,10 +534,10 @@
             
             recs.forEach(item => {
                 let category = 'Outras Recomendações';
-                
+
                 if (item.categoria && item.categoria.includes('vacina')) {
                     category = 'Vacinas';
-                } else if (item.titulo.toLowerCase().includes('mamografia') || 
+                } else if (item.titulo.toLowerCase().includes('mamografia') ||
                           item.titulo.toLowerCase().includes('colonoscopia') ||
                           item.titulo.toLowerCase().includes('citologia') ||
                           item.titulo.toLowerCase().includes('psa') ||
@@ -542,7 +549,7 @@
                           item.titulo.toLowerCase().includes('eletrocardiograma') ||
                           item.titulo.toLowerCase().includes('fundoscopia')) {
                     category = 'Exames de Imagem';
-                } else if (item.categoria === 'laboratorial' ||
+                } else if (isLaboratoryCategory(item.categoria) ||
                           item.titulo.toLowerCase().includes('hba1c') ||
                           item.titulo.toLowerCase().includes('creatinina') ||
                           item.titulo.toLowerCase().includes('perfil') ||


### PR DESCRIPTION
## Summary
- normalize the interactive recommendation pages to accept both `laboratorio` and `laboratorial` after trimming and lowercasing before grouping lab exams
- mirror the same alias-aware helper across the static templates so laboratory filtering treats the two values equivalently with updated inline documentation

## Testing
- not run (static HTML update)

------
https://chatgpt.com/codex/tasks/task_e_68c856ae6b2883309f618c636356204a