### PR TITLE
Mitigate Flask-CORS private network header vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 
 # Patches applied (2025-08-26T12:12:23)
+
+## 2025-09-16
+- Segurança: Remoção explícita do cabeçalho `Access-Control-Allow-Private-Network` em todas as respostas Flask para mitigar o comportamento inseguro introduzido no Flask-CORS 4.0.1.
+- Testes de fumaça verificam a ausência do cabeçalho de rede privada nas rotas principais.
 - index.html
   - Valores normalizados de tabagismo (`fumante_atual` / `ex_fumante`).
   - Seletor de País (BR/EUA) que envia `pais` no payload.

--- a/api/analytics.py
+++ b/api/analytics.py
@@ -1,5 +1,6 @@
 from flask import Flask, jsonify
 import datetime
+from src.utils.cors import sanitize_private_network_header
 
 app = Flask(__name__)
 
@@ -29,11 +30,11 @@ def get_analytics_stats():
         
         response = jsonify(stats)
         response.headers.add('Access-Control-Allow-Origin', '*')
-        return response
+        return sanitize_private_network_header(response)
     except Exception as e:
         error_response = jsonify({'error': str(e)})
         error_response.headers.add('Access-Control-Allow-Origin', '*')
-        return error_response, 500
+        return sanitize_private_network_header(error_response), 500
 
 @app.route('/api/analytics/full', methods=['GET', 'OPTIONS'])
 def get_full_analytics():
@@ -55,11 +56,11 @@ def get_full_analytics():
         
         response = jsonify(full_stats)
         response.headers.add('Access-Control-Allow-Origin', '*')
-        return response
+        return sanitize_private_network_header(response)
     except Exception as e:
         error_response = jsonify({'error': str(e)})
         error_response.headers.add('Access-Control-Allow-Origin', '*')
-        return error_response, 500
+        return sanitize_private_network_header(error_response), 500
 
 def handler(req):
     with app.test_request_context(path=req.path, method=req.method, 

--- a/api/checkup-intelligent.py
+++ b/api/checkup-intelligent.py
@@ -5,6 +5,7 @@ import json
 import math
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
+from src.utils.cors import sanitize_private_network_header
 
 # Add paths
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
@@ -21,7 +22,7 @@ def _corsify(resp):
     resp.headers['Access-Control-Allow-Origin'] = '*'
     resp.headers['Access-Control-Allow-Headers'] = 'Content-Type, Authorization'
     resp.headers['Access-Control-Allow-Methods'] = 'POST, OPTIONS'
-    return resp
+    return sanitize_private_network_header(resp)
 
 
 def parse_date_ymd(date_str):

--- a/api/checkup.py
+++ b/api/checkup.py
@@ -1,4 +1,5 @@
 from flask import Flask, request, jsonify, make_response
+from src.utils.cors import sanitize_private_network_header
 
 app = Flask(__name__)
 
@@ -7,7 +8,7 @@ def _corsify(resp):
     resp.headers['Access-Control-Allow-Origin'] = '*'
     resp.headers['Access-Control-Allow-Headers'] = 'Content-Type, Authorization'
     resp.headers['Access-Control-Allow-Methods'] = 'POST, OPTIONS'
-    return resp
+    return sanitize_private_network_header(resp)
 
 
 @app.route('/checkup', methods=['POST', 'OPTIONS'])

--- a/api/gerar-receita-vacinas.py
+++ b/api/gerar-receita-vacinas.py
@@ -1,4 +1,5 @@
 from flask import Flask, request, make_response
+from src.utils.cors import sanitize_private_network_header
 import json
 
 app = Flask(__name__)
@@ -11,7 +12,7 @@ def _corsify(resp):
     resp.headers['Access-Control-Allow-Origin'] = '*'
     resp.headers['Access-Control-Allow-Headers'] = 'Content-Type, Authorization'
     resp.headers['Access-Control-Allow-Methods'] = 'POST, OPTIONS'
-    return resp
+    return sanitize_private_network_header(resp)
 
 
 @app.route('/', methods=['POST', 'OPTIONS'])

--- a/api/gerar-solicitacao-exames.py
+++ b/api/gerar-solicitacao-exames.py
@@ -1,4 +1,5 @@
 from flask import Flask, request, make_response
+from src.utils.cors import sanitize_private_network_header
 import json
 
 app = Flask(__name__)
@@ -11,7 +12,7 @@ def _corsify(resp):
     resp.headers['Access-Control-Allow-Origin'] = '*'
     resp.headers['Access-Control-Allow-Headers'] = 'Content-Type, Authorization'
     resp.headers['Access-Control-Allow-Methods'] = 'POST, OPTIONS'
-    return resp
+    return sanitize_private_network_header(resp)
 
 
 @app.route('/', methods=['POST', 'OPTIONS'])

--- a/app.py
+++ b/app.py
@@ -10,12 +10,14 @@ from src.routes.checkup import checkup_bp
 from src.routes.checkup_intelligent import checkup_intelligent_bp
 from src.routes.database_api import database_api_bp
 from src.utils.analytics import analytics, track_visit
+from src.utils.cors import register_private_network_sanitizer
 
 app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'src', 'static'))
 app.config['SECRET_KEY'] = 'asdf#FGSgvasgf$5$WGT'
 
 # Habilitar CORS para todas as rotas
 CORS(app)
+register_private_network_sanitizer(app)
 
 app.register_blueprint(user_bp, url_prefix='/api')
 app.register_blueprint(checkup_bp, url_prefix='/api')

--- a/run_server.py
+++ b/run_server.py
@@ -10,10 +10,12 @@ from src.routes.checkup import checkup_bp
 from src.routes.checkup_intelligent import checkup_intelligent_bp
 from src.routes.database_api import database_api_bp
 from src.utils.analytics import analytics, track_visit
+from src.utils.cors import register_private_network_sanitizer
 
 app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'src', 'static'))
 app.config['SECRET_KEY'] = 'asdf#FGSgvasgf$5$WGT'
 CORS(app)
+register_private_network_sanitizer(app)
 app.register_blueprint(user_bp, url_prefix='/api')
 app.register_blueprint(checkup_bp, url_prefix='/api')
 app.register_blueprint(checkup_intelligent_bp)

--- a/scripts/test_smoke.py
+++ b/scripts/test_smoke.py
@@ -9,7 +9,12 @@ Run:
 """
 from __future__ import annotations
 import json
+import os
 import sys
+
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
 
 try:
     from app import app
@@ -22,6 +27,15 @@ def assert_true(cond: bool, msg: str):
     if not cond:
         print(f"[FAIL] {msg}")
         sys.exit(1)
+
+
+def assert_no_private_network_header(resp, label: str):
+    header_value = resp.headers.get('Access-Control-Allow-Private-Network')
+    if header_value is None:
+        return
+    if isinstance(header_value, str) and header_value.strip().lower() == 'false':
+        return
+    assert_true(False, f"{label} leaked Access-Control-Allow-Private-Network={header_value!r}")
 
 
 def post_json(client, path: str, payload: dict, headers: dict | None = None):
@@ -40,6 +54,7 @@ def main():
     }
     r1 = post_json(client, '/checkup-intelligent', payload_25m)
     assert_true(r1.status_code == 200, f"/checkup-intelligent 25M HTTP {r1.status_code}")
+    assert_no_private_network_header(r1, '/checkup-intelligent (25M)')
     data1 = r1.get_json() or {}
     recs1 = data1.get('recommendations') or []
     titles1 = [ (rec.get('titulo') or '').lower() for rec in recs1 ]
@@ -58,6 +73,7 @@ def main():
     }
     r2 = post_json(client, '/checkup-intelligent', payload_55m)
     assert_true(r2.status_code == 200, f"/checkup-intelligent 55M HTTP {r2.status_code}")
+    assert_no_private_network_header(r2, '/checkup-intelligent (55M)')
     data2 = r2.get_json() or {}
     recs2 = data2.get('recommendations') or []
     titles2 = [ (rec.get('titulo') or '').lower() for rec in recs2 ]
@@ -72,6 +88,7 @@ def main():
     r3_json = post_json(client, '/gerar-solicitacao-exames', doc_payload, headers={'Accept': 'application/json'})
     assert_true(r3_json.status_code == 200, f"/gerar-solicitacao-exames JSON HTTP {r3_json.status_code}")
     assert_true((r3_json.content_type or '').startswith('application/json'), f"Expected JSON content-type, got {r3_json.content_type}")
+    assert_no_private_network_header(r3_json, '/gerar-solicitacao-exames (JSON)')
     data3 = r3_json.get_json() or {}
     assert_true(bool(data3.get('html')), "JSON response missing 'html' for /gerar-solicitacao-exames")
 
@@ -80,11 +97,13 @@ def main():
     assert_true(r3_html.status_code == 200, f"/gerar-solicitacao-exames HTML HTTP {r3_html.status_code}")
     assert_true((r3_html.content_type or '').startswith('text/html'), f"Expected HTML content-type, got {r3_html.content_type}")
     assert_true((r3_html.get_data(as_text=True) or '').lstrip().startswith('<!DOCTYPE html>'), "HTML response does not look like HTML for /gerar-solicitacao-exames")
+    assert_no_private_network_header(r3_html, '/gerar-solicitacao-exames (HTML)')
 
     # 5) Vaccine prescription: JSON
     r4_json = post_json(client, '/gerar-receita-vacinas', doc_payload, headers={'Accept': 'application/json'})
     assert_true(r4_json.status_code == 200, f"/gerar-receita-vacinas JSON HTTP {r4_json.status_code}")
     assert_true((r4_json.content_type or '').startswith('application/json'), f"Expected JSON content-type, got {r4_json.content_type}")
+    assert_no_private_network_header(r4_json, '/gerar-receita-vacinas (JSON)')
     data4 = r4_json.get_json() or {}
     assert_true(bool(data4.get('html')), "JSON response missing 'html' for /gerar-receita-vacinas")
 
@@ -93,6 +112,7 @@ def main():
     assert_true(r4_html.status_code == 200, f"/gerar-receita-vacinas HTML HTTP {r4_html.status_code}")
     assert_true((r4_html.content_type or '').startswith('text/html'), f"Expected HTML content-type, got {r4_html.content_type}")
     assert_true((r4_html.get_data(as_text=True) or '').lstrip().startswith('<!DOCTYPE html>'), "HTML response does not look like HTML for /gerar-receita-vacinas")
+    assert_no_private_network_header(r4_html, '/gerar-receita-vacinas (HTML)')
 
     print("[OK] Smoke tests passed.")
 

--- a/src/main.py
+++ b/src/main.py
@@ -11,12 +11,14 @@ from src.routes.checkup import checkup_bp
 from src.routes.checkup_intelligent import checkup_intelligent_bp
 from src.routes.database_api import database_api_bp
 from src.utils.analytics import analytics, track_visit
+from src.utils.cors import register_private_network_sanitizer
 
 app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'static'))
 app.config['SECRET_KEY'] = 'asdf#FGSgvasgf$5$WGT'
 
 # Habilitar CORS para todas as rotas
 CORS(app)
+register_private_network_sanitizer(app)
 
 app.register_blueprint(user_bp, url_prefix='/api')
 app.register_blueprint(checkup_bp, url_prefix='/api')

--- a/src/utils/cors.py
+++ b/src/utils/cors.py
@@ -1,0 +1,22 @@
+"""Utilities to harden CORS behavior across the application."""
+
+from __future__ import annotations
+
+from flask import Flask, Response
+
+_PRIVATE_NETWORK_HEADER = "Access-Control-Allow-Private-Network"
+
+
+def sanitize_private_network_header(response: Response) -> Response:
+    """Strip the Access-Control-Allow-Private-Network header if present."""
+    response.headers.pop(_PRIVATE_NETWORK_HEADER, None)
+    return response
+
+
+def register_private_network_sanitizer(app: Flask) -> None:
+    """Ensure every response emitted by *app* has the private network header removed."""
+
+    @app.after_request
+    def _remove_private_network_header(response: Response) -> Response:  # pragma: no cover - exercised via tests
+        return sanitize_private_network_header(response)
+


### PR DESCRIPTION
## Summary
- strip the Access-Control-Allow-Private-Network header from every Flask response to mitigate the insecure Flask-CORS 4.0.1 default
- add a shared sanitizer helper and update smoke tests to guard against regressions
- document the hardening work in the changelog

## Testing
- python scripts/test_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68c87201292c8330ba626cf68daffe06