### PR TITLE
Adjust Intelligent Tools nav hover styling

### DIFF
--- a/intelligent-tools.html
+++ b/intelligent-tools.html
@@ -78,7 +78,7 @@
             transition: color 0.3s;
         }
 
-        .nav-links a:hover {
+        .nav-links a:not(.back-btn):hover {
             color: #3498db;
         }
 
@@ -94,7 +94,7 @@
 
         .back-btn:hover {
             background: #95a5a6;
-            color: white;
+            color: #374151;
         }
 
         .container {


### PR DESCRIPTION
## Summary
- restrict the navigation link hover state so the back button retains its gray styling
- update the back button hover text color to a darker gray for better contrast

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8c9d462e08330b58643cdb2fc3d04