### PR TITLE
Use absolute favicon paths on static pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Intelligent Tools - Evidens</title>
-    <link rel="icon" type="image/x-icon" href="favicon.ico">
-    <link rel="icon" type="image/png" href="favicon.png">
-    <link rel="apple-touch-icon" href="favicon.png">
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
+    <link rel="icon" type="image/png" href="/favicon.png">
+    <link rel="apple-touch-icon" href="/favicon.png">
     <style>
         * {
             margin: 0;

--- a/intelligent-tools.html
+++ b/intelligent-tools.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Intelligent Tools - Evidens</title>
-    <link rel="icon" type="image/x-icon" href="favicon.ico">
-    <link rel="icon" type="image/png" href="favicon.png">
-    <link rel="apple-touch-icon" href="favicon.png">
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
+    <link rel="icon" type="image/png" href="/favicon.png">
+    <link rel="apple-touch-icon" href="/favicon.png">
     <style>
         * {
             margin: 0;


### PR DESCRIPTION
## Summary
- update the favicon links in `index.html` and `intelligent-tools.html` to use absolute URLs so the icon loads from nested routes

## Testing
- started `python run_server.py` and manually accessed `/`, `/intelligent-tools`, and `/favicon.ico` to confirm the favicon is served

------
https://chatgpt.com/codex/tasks/task_e_68c8c9ebe1288330a81a4a2395dd82d0