### PR TITLE
Serve favicon from root without duplicating binary

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,8 @@
 import os
 import sys
-sys.path.insert(0, os.path.dirname(__file__))
+
+BASE_DIR = os.path.dirname(__file__)
+sys.path.insert(0, BASE_DIR)
 
 from flask import Flask, send_from_directory, jsonify
 from flask_cors import CORS
@@ -12,7 +14,7 @@ from src.routes.database_api import database_api_bp
 from src.utils.analytics import analytics, track_visit
 from src.utils.cors import register_private_network_sanitizer
 
-app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'src', 'static'))
+app = Flask(__name__, static_folder=os.path.join(BASE_DIR, 'src', 'static'))
 app.config['SECRET_KEY'] = 'asdf#FGSgvasgf$5$WGT'
 
 # Habilitar CORS para todas as rotas
@@ -25,12 +27,21 @@ app.register_blueprint(checkup_intelligent_bp, url_prefix='/api')
 app.register_blueprint(database_api_bp)
 
 # Database configuration
-app.config['SQLALCHEMY_DATABASE_URI'] = f"sqlite:///{os.path.join(os.path.dirname(__file__), 'src', 'database', 'app.db')}"
+app.config['SQLALCHEMY_DATABASE_URI'] = f"sqlite:///{os.path.join(BASE_DIR, 'src', 'database', 'app.db')}"
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 db.init_app(app)
 
 with app.app_context():
     db.create_all()
+
+@app.route('/favicon.png')
+def serve_favicon_png():
+    """Serve the PNG favicon stored at the project root."""
+    favicon_path = os.path.join(BASE_DIR, 'favicon.png')
+    if os.path.exists(favicon_path):
+        return send_from_directory(BASE_DIR, 'favicon.png')
+    return ("", 404)
+
 
 @app.route('/analytics/stats')
 def get_analytics_stats():

--- a/build.py
+++ b/build.py
@@ -38,6 +38,18 @@ def copy_static_files(build_dir):
     
     return True
 
+
+def copy_root_favicon(build_dir):
+    """Garante que o favicon.png presente na raiz seja incluído no build."""
+    root_favicon = SCRIPT_DIR / "favicon.png"
+    if not root_favicon.exists():
+        print("⚠️ favicon.png não encontrado na raiz do projeto")
+        return
+
+    destination = build_dir / "favicon.png"
+    shutil.copy2(root_favicon, destination)
+    print("✅ Copiado: favicon.png (raiz)")
+
 def create_redirects(build_dir):
     """Cria arquivo _redirects para SPA routing"""
     redirects_content = """# SPA redirects
@@ -81,6 +93,7 @@ def update_html_for_static(build_dir):
     # Atualiza referências para funcionar como site estático
     # Se houver chamadas para /api/, você precisará configurar um backend alternativo
     content = content.replace('href="/favicon.ico"', 'href="./favicon.ico"')
+    content = content.replace('href="/favicon.png"', 'href="./favicon.png"')
     
     with open(index_path, "w", encoding="utf-8") as f:
         f.write(content)
@@ -97,7 +110,9 @@ def main():
     if not copy_static_files(build_dir):
         print("❌ Falha ao copiar arquivos estáticos")
         return False
-    
+
+    copy_root_favicon(build_dir)
+
     create_redirects(build_dir)
     create_headers(build_dir)
     update_html_for_static(build_dir)

--- a/run_server.py
+++ b/run_server.py
@@ -1,6 +1,8 @@
 import os
 import sys
-sys.path.insert(0, os.path.dirname(__file__))
+
+BASE_DIR = os.path.dirname(__file__)
+sys.path.insert(0, BASE_DIR)
 
 from flask import Flask, send_from_directory
 from flask_cors import CORS
@@ -12,7 +14,7 @@ from src.routes.database_api import database_api_bp
 from src.utils.analytics import analytics, track_visit
 from src.utils.cors import register_private_network_sanitizer
 
-app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'src', 'static'))
+app = Flask(__name__, static_folder=os.path.join(BASE_DIR, 'src', 'static'))
 app.config['SECRET_KEY'] = 'asdf#FGSgvasgf$5$WGT'
 CORS(app)
 register_private_network_sanitizer(app)
@@ -22,11 +24,20 @@ app.register_blueprint(checkup_intelligent_bp, url_prefix='/api')
 app.register_blueprint(database_api_bp)
 
 # Database configuration
-app.config['SQLALCHEMY_DATABASE_URI'] = f"sqlite:///{os.path.join(os.path.dirname(__file__), 'src', 'database', 'app.db')}"
+app.config['SQLALCHEMY_DATABASE_URI'] = f"sqlite:///{os.path.join(BASE_DIR, 'src', 'database', 'app.db')}"
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 db.init_app(app)
 with app.app_context():
     db.create_all()
+
+@app.route('/favicon.png')
+def serve_favicon_png():
+    """Serve the PNG favicon stored at the project root."""
+    favicon_path = os.path.join(BASE_DIR, 'favicon.png')
+    if os.path.exists(favicon_path):
+        return send_from_directory(BASE_DIR, 'favicon.png')
+    return ("", 404)
+
 
 @app.route('/analytics/stats')
 def get_analytics_stats():


### PR DESCRIPTION
## Summary
- expose `/favicon.png` directly from the existing root asset so the Flask servers can return it without storing a duplicate binary
- copy the root favicon into the static build output to keep the PNG available after running the deployment helper
- centralize the base directory constant for both server entrypoints when configuring the static folder and database path

## Testing
- python build.py
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68c8ce7f54d48330814c042841ce9906