### PR TITLE
Handle invalid recommendation inputs gracefully

### DIFF
--- a/intelligent-tools.html
+++ b/intelligent-tools.html
@@ -649,14 +649,24 @@
                     },
                     body: JSON.stringify(data)
                 });
-                
-                if (!response.ok) {
-                    throw new Error(`Erro HTTP: ${response.status}`);
+
+                let result = null;
+                try {
+                    result = await response.json();
+                } catch (parseError) {
+                    if (!response.ok) {
+                        throw new Error(`Erro HTTP: ${response.status}`);
+                    }
+                    throw parseError;
                 }
-                
-                const result = await response.json();
-                displayRecommendations(result.recommendations, cardiovascularRisk);
-                
+
+                if (!response.ok) {
+                    const errorMessage = (result && (result.error || result.message)) || `Erro HTTP: ${response.status}`;
+                    throw new Error(errorMessage);
+                }
+
+                displayRecommendations(result?.recommendations || [], result?.prevent_risk || cardiovascularRisk);
+
             } catch (error) {
                 console.error('Erro:', error);
                 alert('Erro ao gerar recomendações: ' + error.message);


### PR DESCRIPTION
## Summary
- harden the /checkup-intelligent backend to sanitize numeric fields, detect missing age, and serialize medication data before persisting
- bubble backend error messages to the intelligent tools page so the user sees validation feedback instead of generic HTTP codes
- update the serverless checkup-intelligent handler to share the same validation and JSON response helpers

## Testing
- python - <<'PY'
from src.main import app
client = app.test_client()
resp = client.post('/api/checkup-intelligent', json={'idade': '', 'sexo': 'masculino'})
print(resp.status_code)
print(resp.json)
PY
- python - <<'PY'
from src.main import app
client = app.test_client()
data = {
    'idade': '45',
    'sexo': 'masculino',
    'peso': '80',
    'altura': '175',
    'colesterol': '210',
    'hdl': '45',
    'pas': '130',
    'pad': '85',
    'creatinina': '1.1',
    'tabagismo': 'atual',
    'macos_ano': '10',
    'medicacoes': ['anti_hipertensivos', 'estatinas'],
    'medicacoes_continuo': 'Losartana 50mg 1x/dia',
    'comorbidades': ['diabetes'],
    'historia_familiar': 'cardiopatia'
}
resp = client.post('/api/checkup-intelligent', json=data)
print(resp.status_code)
print(resp.json['risk_classification'])
print(len(resp.json['recommendations']))
PY
- python - <<'PY'
from src.main import app
client = app.test_client()
resp = client.post('/api/checkup-intelligent', json={'idade': '45a', 'sexo': 'masculino'})
print(resp.status_code)
print(resp.json)
PY

------
https://chatgpt.com/codex/tasks/task_e_68c8dcfc5e4483309e535649bec32636