### PR TITLE
Refatora cabeçalho para parcial compartilhada

### DIFF
--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -1,0 +1,112 @@
+.header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 1rem 2rem;
+    background: rgba(255, 255, 255, 0.95);
+    backdrop-filter: blur(10px);
+    box-shadow: 0 2px 20px rgba(0, 0, 0, 0.1);
+    z-index: 100;
+    line-height: 1;
+}
+
+.nav {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin: 0 auto;
+    max-width: 1200px;
+    position: relative;
+    min-height: 3.5rem;
+}
+
+.nav-links {
+    display: flex;
+    align-items: center;
+    gap: 2rem;
+}
+
+.nav-links a {
+    color: #2c3e50;
+    text-decoration: none;
+    font-weight: 500;
+    transition: color 0.3s ease, background-color 0.3s ease;
+    line-height: 1.2;
+    padding: 0.25rem 0;
+}
+
+.nav-links a:hover {
+    color: #3498db;
+}
+
+.logo {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    text-decoration: none;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    line-height: 1;
+}
+
+.logo-main {
+    font-size: 1.8rem;
+    font-weight: 300;
+    color: #2c3e50;
+}
+
+.logo-sub {
+    font-size: 1.1rem;
+    font-weight: 300;
+    font-style: italic;
+    color: #27ae60;
+    letter-spacing: 0.05em;
+}
+
+.back-btn {
+    background: #bdc3c7;
+    color: #ffffff;
+    padding: 0.5rem 1rem;
+    border-radius: 999px;
+    transition: background 0.3s ease, color 0.3s ease;
+    line-height: 1.2;
+}
+
+.back-btn:hover {
+    background: #95a5a6;
+    color: #374151;
+}
+
+@media (max-width: 768px) {
+    .header {
+        padding: 0.85rem 1.5rem;
+    }
+
+    .nav {
+        max-width: 100%;
+    }
+
+    .nav-links {
+        gap: 1.25rem;
+    }
+
+    .logo-main {
+        font-size: 1.5rem;
+    }
+}
+
+@media (max-width: 480px) {
+    .header {
+        padding: 0.75rem 1rem;
+    }
+
+    .nav-links {
+        gap: 1rem;
+    }
+
+    .logo-main {
+        font-size: 1.3rem;
+    }
+}

--- a/assets/js/header.js
+++ b/assets/js/header.js
@@ -1,0 +1,129 @@
+(function () {
+    const placeholder = document.getElementById('header-placeholder');
+    if (!placeholder) {
+        return;
+    }
+
+    const scriptElement = document.currentScript;
+    const config = window.headerConfig || {};
+
+    const resolveUrl = (path) => {
+        try {
+            return new URL(path, window.location.href).toString();
+        } catch (error) {
+            return path;
+        }
+    };
+
+    let partialUrl = config.partialPath ? resolveUrl(config.partialPath) : null;
+
+    if (!partialUrl) {
+        if (scriptElement && scriptElement.src) {
+            partialUrl = new URL('../../partials/header.html', scriptElement.src).toString();
+        } else {
+            partialUrl = resolveUrl('/partials/header.html');
+        }
+    }
+
+    fetch(partialUrl)
+        .then((response) => {
+            if (!response.ok) {
+                throw new Error(`Falha ao buscar parcial: ${response.status}`);
+            }
+            return response.text();
+        })
+        .then((html) => {
+            placeholder.innerHTML = html;
+            applyHeaderConfig(placeholder, config);
+            try {
+                delete window.headerConfig;
+            } catch (error) {
+                window.headerConfig = undefined;
+            }
+        })
+        .catch((error) => {
+            console.error('Erro ao carregar cabeçalho compartilhado:', error);
+        });
+
+    function applyHeaderConfig(root, config) {
+        const { logo = {}, leftLinks = [], rightLinks = [] } = config;
+        const navLeft = root.querySelector('.nav-left');
+        const navRight = root.querySelector('.nav-right');
+        const logoLink = root.querySelector('.logo');
+        const logoMain = root.querySelector('.logo-main');
+        const logoSub = root.querySelector('.logo-sub');
+
+        if (logoLink && logo.href) {
+            logoLink.setAttribute('href', logo.href);
+        }
+
+        if (logoLink && logo.ariaLabel) {
+            logoLink.setAttribute('aria-label', logo.ariaLabel);
+        }
+
+        if (logoLink && logo.className) {
+            const classValues = Array.isArray(logo.className)
+                ? logo.className
+                : String(logo.className).split(' ');
+
+            classValues
+                .filter(Boolean)
+                .forEach((cls) => logoLink.classList.add(cls));
+        }
+
+        if (logoMain && logo.main) {
+            logoMain.textContent = logo.main;
+        }
+
+        if (logoSub) {
+            if (logo.sub) {
+                logoSub.textContent = logo.sub;
+            } else {
+                logoSub.remove();
+            }
+        }
+
+        const populateLinks = (container, links) => {
+            if (!container) {
+                return;
+            }
+
+            container.innerHTML = '';
+
+            if (!Array.isArray(links)) {
+                return;
+            }
+
+            links.forEach((link) => {
+                if (!link || !link.text) {
+                    return;
+                }
+
+                const anchor = document.createElement('a');
+                anchor.textContent = link.text;
+                anchor.href = link.href || '#';
+
+                if (link.className) {
+                    anchor.className = link.className;
+                }
+
+                if (link.target) {
+                    anchor.target = link.target;
+                }
+
+                if (link.rel) {
+                    anchor.rel = link.rel;
+                }
+
+                if (link.ariaLabel) {
+                    anchor.setAttribute('aria-label', link.ariaLabel);
+                }
+
+                container.appendChild(anchor);
+            });
+        };
+
+        populateLinks(navLeft, leftLinks);
+        populateLinks(navRight, rightLinks);
+    }
+})();

--- a/index.html
+++ b/index.html
@@ -7,6 +7,23 @@
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="icon" type="image/png" href="/favicon.png">
     <link rel="apple-touch-icon" href="/favicon.png">
+    <link rel="stylesheet" href="assets/css/header.css">
+    <script>
+        window.headerConfig = {
+            logo: {
+                href: '/',
+                main: 'evidēns',
+                ariaLabel: 'Ir para a página inicial da Evidēns'
+            },
+            leftLinks: [
+                { text: 'About', href: '#about' }
+            ],
+            rightLinks: [
+                { text: 'Contact', href: '#contact' }
+            ]
+        };
+    </script>
+    <script src="assets/js/header.js" defer></script>
     <style>
         * {
             margin: 0;
@@ -20,51 +37,6 @@
             color: #2c3e50;
             background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
             min-height: 100vh;
-        }
-
-        .header {
-            background: rgba(255, 255, 255, 0.95);
-            backdrop-filter: blur(10px);
-            padding: 1rem 2rem;
-            box-shadow: 0 2px 20px rgba(0,0,0,0.1);
-            position: fixed;
-            width: 100%;
-            top: 0;
-            z-index: 100;
-        }
-
-        .nav {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            max-width: 1200px;
-            margin: 0 auto;
-        }
-
-        .logo {
-            font-size: 2rem;
-            font-weight: 300;
-            color: #2c3e50;
-            text-decoration: none;
-            position: absolute;
-            left: 50%;
-            transform: translateX(-50%);
-        }
-
-        .nav-links {
-            display: flex;
-            gap: 2rem;
-        }
-
-        .nav-links a {
-            color: #2c3e50;
-            text-decoration: none;
-            font-weight: 500;
-            transition: color 0.3s;
-        }
-
-        .nav-links a:hover {
-            color: #3498db;
         }
 
         .hero {
@@ -292,25 +264,9 @@
                 gap: 2rem;
                 padding: 0 1rem 3rem;
             }
-            
+
             .feature-card {
                 padding: 2rem 1.5rem;
-            }
-            
-            .nav {
-                padding: 0 1rem;
-            }
-            
-            .logo {
-                font-size: 1.5rem;
-            }
-            
-            .nav-links {
-                gap: 1rem;
-            }
-            
-            .nav-links a {
-                font-size: 0.9rem;
             }
             
             .search-input {
@@ -342,34 +298,19 @@
             .feature-card {
                 padding: 1.5rem 1rem;
             }
-            
+
             .feature-icon {
                 font-size: 2.5rem;
             }
-            
+
             .feature-card h3 {
-                font-size: 1.3rem;
-            }
-            
-            .logo {
                 font-size: 1.3rem;
             }
         }
     </style>
 </head>
 <body>
-    <!-- Header Navigation -->
-    <header class="header">
-        <nav class="nav">
-            <div class="nav-links">
-                <a href="#about">About</a>
-            </div>
-            <a href="#" class="logo">evidēns</a>
-            <div class="nav-links">
-                <a href="#contact">Contact</a>
-            </div>
-        </nav>
-    </header>
+    <div id="header-placeholder"></div>
 
     <!-- Hero Section -->
     <section class="hero">

--- a/intelligent-tools.html
+++ b/intelligent-tools.html
@@ -7,6 +7,24 @@
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="icon" type="image/png" href="/favicon.png">
     <link rel="apple-touch-icon" href="/favicon.png">
+    <link rel="stylesheet" href="assets/css/header.css">
+    <script>
+        window.headerConfig = {
+            logo: {
+                href: '/',
+                main: 'evidēns',
+                sub: 'check',
+                ariaLabel: 'Ir para a página inicial da Evidēns'
+            },
+            leftLinks: [
+                { text: '← Voltar', href: '/', className: 'back-btn', ariaLabel: 'Voltar para a página inicial' }
+            ],
+            rightLinks: [
+                { text: 'Contact', href: '#contact' }
+            ]
+        };
+    </script>
+    <script src="assets/js/header.js" defer></script>
     <style>
         * {
             margin: 0;
@@ -20,81 +38,6 @@
             color: #2c3e50;
             background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
             min-height: 100vh;
-        }
-
-        .header {
-            background: rgba(255, 255, 255, 0.95);
-            backdrop-filter: blur(10px);
-            padding: 1rem 2rem;
-            box-shadow: 0 2px 20px rgba(0,0,0,0.1);
-            position: fixed;
-            width: 100%;
-            top: 0;
-            z-index: 100;
-        }
-
-        .nav {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            max-width: 1200px;
-            margin: 0 auto;
-        }
-
-        .logo {
-            position: absolute;
-            left: 50%;
-            transform: translateX(-50%);
-            text-decoration: none;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            line-height: 1;
-        }
-
-        .logo-main {
-            font-size: 1.8rem;
-            font-weight: 300;
-            color: #2c3e50;
-            margin-bottom: -5px;
-        }
-
-        .logo-sub {
-            font-size: 1.2rem;
-            font-weight: 300;
-            font-style: italic;
-            color: #27ae60;
-        }
-
-        .nav-links {
-            display: flex;
-            gap: 2rem;
-        }
-
-        .nav-links a {
-            color: #2c3e50;
-            text-decoration: none;
-            font-weight: 500;
-            transition: color 0.3s;
-        }
-
-        .nav-links a:not(.back-btn):hover {
-            color: #3498db;
-        }
-
-        .back-btn {
-            background: #bdc3c7;
-            color: white;
-            padding: 0.5rem 1rem;
-            border-radius: 20px;
-            text-decoration: none;
-            font-weight: 500;
-            transition: background 0.3s;
-        }
-
-        .back-btn:hover {
-            background: #95a5a6;
-            color: #374151;
         }
 
         .container {
@@ -334,18 +277,6 @@
                 grid-template-columns: 1fr;
             }
             
-            .nav {
-                padding: 0 1rem;
-            }
-            
-            .logo {
-                font-size: 1.5rem;
-            }
-            
-            .nav-links a {
-                font-size: 0.9rem;
-            }
-            
             .hero {
                 padding: 4rem 1rem 2rem;
             }
@@ -389,29 +320,11 @@
                 width: 100%;
                 padding: 1rem;
             }
-            
-            .logo {
-                font-size: 1.3rem;
-            }
         }
     </style>
 </head>
 <body>
-    <!-- Header Navigation -->
-    <header class="header">
-        <nav class="nav">
-            <div class="nav-links">
-                <a href="/" class="back-btn">← Voltar</a>
-            </div>
-            <a href="/" class="logo">
-                <span class="logo-main">evidēns</span>
-                <span class="logo-sub">check</span>
-            </a>
-            <div class="nav-links">
-                <a href="#contact">Contact</a>
-            </div>
-        </nav>
-    </header>
+    <div id="header-placeholder"></div>
 
     <div class="container">
 

--- a/partials/header.html
+++ b/partials/header.html
@@ -1,0 +1,10 @@
+<header class="header">
+    <nav class="nav">
+        <div class="nav-links nav-left"></div>
+        <a href="/" class="logo" aria-label="Página inicial da Evidēns">
+            <span class="logo-main">evidēns</span>
+            <span class="logo-sub">check</span>
+        </a>
+        <div class="nav-links nav-right"></div>
+    </nav>
+</header>


### PR DESCRIPTION
## Summary
- cria a parcial `partials/header.html` e um script para injetá-la dinamicamente nas páginas principais
- move o CSS do cabeçalho para `assets/css/header.css` garantindo a mesma altura e aparência nas duas telas
- adapta `index.html` e `intelligent-tools.html` para usar o novo cabeçalho compartilhado e a configuração declarativa

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9648713f08330a8104de3267838ec