### PR TITLE
Add missing fpdf2 dependency for exam request generation

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -2,3 +2,4 @@ Flask==3.1.1
 python-dateutil==2.9.0.post0
 flask-cors==4.0.0
 flask-sqlalchemy==3.0.5
+fpdf2>=2.7.0


### PR DESCRIPTION
## Summary
- include fpdf2 in the serverless API requirements so gerar-solicitacao-exames can import FPDF in production

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca034c9c648330bbe37aca94d23368