### PR TITLE
Harden exam request PDF generation against missing data

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -2,3 +2,4 @@ Flask==3.1.1
 python-dateutil==2.9.0.post0
 flask-cors==4.0.0
 flask-sqlalchemy==3.0.5
+fpdf2>=2.7.0


### PR DESCRIPTION
## Summary
- sanitize incoming exam request payloads before building PDFs so optional sections like `medico` or `patient_data` no longer trigger server errors
- filter invalid exam entries and reuse sanitized patient names when building file names to keep PDF creation stable even with incomplete data

## Testing
- python -m compileall api/gerar-solicitacao-exames.py

------
https://chatgpt.com/codex/tasks/task_e_68ca034c9c648330bbe37aca94d23368