### PR TITLE
Fix Outras recommendations display

### DIFF
--- a/intelligent-tools.html
+++ b/intelligent-tools.html
@@ -807,6 +807,8 @@
             const categorias = {
                 '🧪 Exames Laboratoriais': [],
                 '🏥 Exames de Imagem': [],
+                '💉 Vacinas': [],
+                '🩺 Avaliação Clínica': [],
                 '📋 Outras Recomendações': []
             };
             

--- a/scripts/test_smoke.py
+++ b/scripts/test_smoke.py
@@ -62,6 +62,9 @@ def main():
     titles1 = [(rec.get('titulo') or '').lower() for rec in recs1]
     assert_true(any('gardasil 9' in t for t in titles1), "HPV (Gardasil 9) not found for 25M")
     assert_true(any('hepatite b' in t for t in titles1), "Hepatite B not found for 25M")
+    assert_true(any('questionário gad-7' in t for t in titles1), "GAD-7 screening not found for 25M")
+    assert_true(any('questionário phq-9' in t for t in titles1), "PHQ-9 screening not found for 25M")
+    assert_true(any('prep' in t for t in titles1), "HIV PrEP guidance not found for 25M")
 
     # Reference HTML presence (at least one rec with referencia_html)
     assert_true(any((rec.get('referencia_html') or '') for rec in recs1),

--- a/src/routes/checkup_intelligent.py
+++ b/src/routes/checkup_intelligent.py
@@ -417,7 +417,40 @@ def generate_age_sex_recommendations(age, sex, country='BR'):
             'referencia': 'SBIm/ANVISA 2024',
             'grau_evidencia': 'A'
         })
-    
+
+    # Outras recomendações preventivas (triagens e profilaxia)
+    if 18 <= age <= 64:
+        _add_rec({
+            'titulo': 'Questionário GAD-7 (Triagem de Ansiedade)',
+            'descricao': 'Rastreamento de ansiedade para adultos até 64 anos, incluindo gestantes e puérperas.',
+            'subtitulo': 'Detecção precoce de transtornos de ansiedade',
+            'categoria': 'outras',
+            'prioridade': 'media',
+            'referencia': 'USPSTF 2023 Grau B',
+            'grau_evidencia': 'B'
+        })
+
+    if age >= 18:
+        _add_rec({
+            'titulo': 'Questionário PHQ-9 (Triagem de Depressão)',
+            'descricao': 'Rastreamento de depressão em adultos, incluindo gestantes, puérperas e idosos.',
+            'subtitulo': 'Avaliação sistemática de sintomas depressivos',
+            'categoria': 'outras',
+            'prioridade': 'media',
+            'referencia': 'USPSTF 2023 Grau B',
+            'grau_evidencia': 'B'
+        })
+
+        _add_rec({
+            'titulo': 'Profilaxia Pré-Exposição ao HIV (PrEP)',
+            'descricao': 'Oferecer PrEP para adultos e adolescentes ≥35 kg com risco aumentado de infecção pelo HIV.',
+            'subtitulo': 'Prevenção combinada do HIV',
+            'categoria': 'outras',
+            'prioridade': 'alta',
+            'referencia': 'USPSTF 2023 Grau A',
+            'grau_evidencia': 'A'
+        })
+
     return recommendations
 
 @checkup_intelligent_bp.route('/checkup-intelligent', methods=['POST'])

--- a/src/utils/reference_links.py
+++ b/src/utils/reference_links.py
@@ -24,6 +24,13 @@ def _contains_any(haystack: str, needles: List[str]) -> bool:
     return any(n in haystack for n in needles)
 
 def _uspstf_url_by_title(title_lc: str) -> str:
+    if _contains_any(title_lc, [
+        'prep', 'pre-exposicao', 'pre exposicao', 'preexposicao',
+        'profilaxia pre-exposicao', 'profilaxia pre exposicao', 'profilaxia preexposicao'
+    ]):
+        return 'https://www.uspreventiveservicestaskforce.org/uspstf/recommendation/prevention-of-human-immunodeficiency-virus-hiv-infection-pre-exposure-prophylaxis'
+    if _contains_any(title_lc, ['ansiedade', 'gad-7', 'gad7', 'anxiety']):
+        return 'https://www.uspreventiveservicestaskforce.org/uspstf/recommendation/anxiety-adults-screening'
     if _contains_any(title_lc, ['hiv']):
         return 'https://www.uspreventiveservicestaskforce.org/uspstf/recommendation/human-immunodeficiency-virus-hiv-infection-screening'
     if _contains_any(title_lc, ['hepatite c', 'hcv']):


### PR DESCRIPTION
## Summary
- ensure the intelligent tools UI defines the vaccine and clinical buckets so Outras recommendations render
- extend the smoke test to assert the new mental health and PrEP items are returned by the API

## Testing
- pytest
- python scripts/test_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68ca0b43c7d48330af947707c78d2c0f