### PR TITLE
Ensure microalbuminuria reference stays a direct URL

### DIFF
--- a/intelligent-tools.html
+++ b/intelligent-tools.html
@@ -610,6 +610,17 @@
         
         // Função para criar links clicáveis nas referências
         function createReferenceLink(referencia) {
+            const trimmed = (referencia || '').trim();
+
+            if (!trimmed) {
+                return '';
+            }
+
+            if (/^https?:\/\//i.test(trimmed)) {
+                const safeUrl = trimmed.replace(/"/g, '&quot;');
+                return `<a href="${safeUrl}" target="_blank" style="color: #3498db; text-decoration: none; border-bottom: 1px dotted #3498db;" onmouseover="this.style.color='#2980b9'" onmouseout="this.style.color='#3498db'">${safeUrl}</a>`;
+            }
+
             const referenceLinks = {
                 'USPSTF 2024': 'https://www.uspreventiveservicestaskforce.org/uspstf/recommendation/breast-cancer-screening',
                 'USPSTF 2023 - Triagem de Ansiedade': 'https://www.uspreventiveservicestaskforce.org/uspstf/recommendation/anxiety-adults-screening',
@@ -633,21 +644,21 @@
                 'SBC/SBH/SBN 2020': 'https://abccardiol.org/article/diretrizes-brasileiras-de-hipertensao-arterial-2020/',
                 'ASE 2016': 'https://www.onlinejase.com/article/S0894-7317(16)30146-4/fulltext'
             };
-            
+
             // Tratamento especial para "AHA/ACC 2025 e SBC 2020"
-            if (referencia === "AHA/ACC 2025 e SBC 2020") {
+            if (trimmed === "AHA/ACC 2025 e SBC 2020") {
                 return `<a href="https://www.ahajournals.org/doi/10.1161/CIR.0000000000001356" target="_blank" style="color: #3498db; text-decoration: none; border-bottom: 1px dotted #3498db;" onmouseover="this.style.color='#2980b9'" onmouseout="this.style.color='#3498db'">AHA/ACC 2025</a> e <a href="https://abccardiol.org/article/diretrizes-brasileiras-de-hipertensao-arterial-2020/" target="_blank" style="color: #3498db; text-decoration: none; border-bottom: 1px dotted #3498db;" onmouseover="this.style.color='#2980b9'" onmouseout="this.style.color='#3498db'">SBC 2020</a>`;
             }
-            
+
             // Procurar por correspondências exatas ou parciais
             for (const [key, url] of Object.entries(referenceLinks)) {
-                if (referencia.includes(key)) {
-                    return `<a href="${url}" target="_blank" style="color: #3498db; text-decoration: none; border-bottom: 1px dotted #3498db;" onmouseover="this.style.color='#2980b9'" onmouseout="this.style.color='#3498db'">${referencia}</a>`;
+                if (trimmed.includes(key)) {
+                    return `<a href="${url}" target="_blank" style="color: #3498db; text-decoration: none; border-bottom: 1px dotted #3498db;" onmouseover="this.style.color='#2980b9'" onmouseout="this.style.color='#3498db'">${trimmed}</a>`;
                 }
             }
 
             // Se não encontrar link específico, retornar texto normal
-            return referencia;
+            return trimmed;
         }
 
         function normalizeText(value) {

--- a/src/routes/checkup_intelligent.py
+++ b/src/routes/checkup_intelligent.py
@@ -15,7 +15,7 @@ checkup_intelligent_bp = Blueprint('checkup_intelligent', __name__)
 REFERENCE_OVERRIDE_RULES = [
     {
         'keywords': ['microalbuminuria', 'urina'],
-        'label': 'AHA/ACC 2025',
+        'label': 'https://www.ahajournals.org/doi/10.1161/CIR.0000000000001356',
         'url': 'https://www.ahajournals.org/doi/10.1161/CIR.0000000000001356'
     },
     {

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -800,7 +800,8 @@
             const titleNormalized = normalizeText(rec.titulo || '');
 
             if (titleNormalized.includes('microalbuminuria') && titleNormalized.includes('urina')) {
-                return '<a href="https://www.ahajournals.org/doi/10.1161/CIR.0000000000001356" target="_blank" rel="noopener noreferrer">AHA/ACC 2025</a>';
+                const url = 'https://www.ahajournals.org/doi/10.1161/CIR.0000000000001356';
+                return `<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>`;
             }
 
             if (titleNormalized.includes('densitometria') && titleNormalized.includes('dexa')) {


### PR DESCRIPTION
## Summary
- override the microalbuminúria exam reference so the stored value is the direct AHA/ACC link
- update the web UIs to render raw URL references (including microalbuminúria) as clickable links instead of guideline labels

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca1dc3e4d483309b69956e6292b23c