### PR TITLE
Fix Vercel handler passthrough responses

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -261,7 +261,17 @@ def handler(request):
         headers=headers,
         query_string=query_string,
     ):
-        return app.full_dispatch_request()
+        response = app.full_dispatch_request()
+
+        # ``send_from_directory`` sets ``direct_passthrough`` so Flask can stream
+        # files efficiently.  The Vercel runtime eagerly reads the body from the
+        # returned response, which raises ``RuntimeError`` if passthrough mode is
+        # still enabled.  Disabling it keeps the response compatible without
+        # affecting normal Flask behaviour.
+        if getattr(response, "direct_passthrough", False):
+            response.direct_passthrough = False
+
+        return response
 
 if __name__ == '__main__':
     app.run(debug=True)


### PR DESCRIPTION
## Summary
- disable Flask direct passthrough before returning from the Vercel handler so static files can be serialized without runtime errors

## Testing
- pytest *(fails: missing optional dependency `argon2` required by other modules)*

------
https://chatgpt.com/codex/tasks/task_e_68cbfc7b08888330b18fcd1a75712fe2